### PR TITLE
修复了手机测试中发现的连接失败后 连接不上始终显示连接中状态

### DIFF
--- a/android/src/main/java/gao/xiaolei/flutter_blue_elves/FlutterBlueElvesPlugin.java
+++ b/android/src/main/java/gao/xiaolei/flutter_blue_elves/FlutterBlueElvesPlugin.java
@@ -150,10 +150,13 @@ public class FlutterBlueElvesPlugin implements FlutterPlugin, MethodCallHandler,
                     Device toConnectDevice = new Device(context, mHandler,cache, mConnectStateCallback, mDeviceSignalCallback, myDiscoverServiceCallback,mtuChangeCallback,rssiChangeCallback,(int) connectParamsMap.get("rssi"));
                     devicesMap.put(connectDeviceId,toConnectDevice);
                     int timeout=(int) connectParamsMap.get("timeout");
-                    if(toConnectDevice.isInBleCache())//如果在蓝牙堆栈里就可以直接连接
-                        toConnectDevice.connectDevice(timeout);
-                    else//如果不在蓝牙堆栈里就要先扫描再连接
-                        scanDevices(false,timeout ,true,connectDeviceId);
+                    // if(toConnectDevice.isInBleCache())//如果在蓝牙堆栈里就可以直接连接
+                    
+                    // Fixed issue when connection failed. 2023 06 30
+                    toConnectDevice.connectDevice(timeout);
+                    
+                    // else//如果不在蓝牙堆栈里就要先扫描再连接
+                    //     scanDevices(false,timeout ,true,connectDeviceId);
                     result.success(true);
                 } else result.success(false);
                 break;


### PR DESCRIPTION
在 Google Pixel 6 pro (Android 14)手机测试 BLE 连接时 经常连接失败并返回连接中状态, 经排查 是蓝牙堆栈的问题导致的, 具体的原因不太清楚, 在蓝牙堆栈里直接连接修复了这个问题.